### PR TITLE
fix(ga4): bugfixes

### DIFF
--- a/deployment/sync-ga-data.yml
+++ b/deployment/sync-ga-data.yml
@@ -149,7 +149,7 @@ Resources:
       ScheduleExpression: "rate(1 hour)"
       Targets:
         - Arn: !GetAtt Lambda.Arn
-          Id: CronEvent2LambdaTarget
+          Id: CronEvent3LambdaTarget
           Input: |
             {
               "type": "2 days ago"
@@ -167,7 +167,7 @@ Resources:
       ScheduleExpression: "rate(1 hour)"
       Targets:
         - Arn: !GetAtt Lambda.Arn
-          Id: CronEvent2LambdaTarget
+          Id: CronEvent4LambdaTarget
           Input: |
             {
               "type": "3 days ago"

--- a/lib/ga4.ts
+++ b/lib/ga4.ts
@@ -127,12 +127,12 @@ const pathToId = async (path: string) => {
 };
 
 const hashToId = async (hash: string) => {
-  const res = await knexRO("article")
+  const res = await knexRO("draft")
     .where({ mediaHash: hash })
-    .select("id")
+    .select("article_id")
     .first();
   if (res) {
-    return res.id;
+    return res.articleId;
   } else {
     return null;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda-handlers-image",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
- fix cloudformation template
- query article id from draft table instead of article table,  as  draft table contains old version articles' media_hashs