### PR TITLE
fix(like): skip CANNOT_SELF_LIKE errors

### DIFF
--- a/lib/likecoin.ts
+++ b/lib/likecoin.ts
@@ -221,7 +221,8 @@ export class LikeCoin {
       },
     })
     const data = result?.data
-    if (data === 'OK') {
+    // filter CANNOT_SELF_LIKE error, self-like is allowed in Matters
+    if (data === 'OK' || data === 'CANNOT_SELF_LIKE') {
       return data
     } else {
       throw result

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda-handlers-image",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Self-like is allowed in Matters but not in Likecoin. 

Self-like requests should not be sent by matters,  but there are already many self-like jobs in  queue, so we have to filter these request errors first to clear queue.